### PR TITLE
Extend + refactor user models for admin type

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -99,7 +99,7 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 [BASIC]
 
 # Good variable names which should always be accepted, separated by a comma
-good-names=i,j,k,ex,Run,_
+good-names=i,j,k,ex,Run,_,id
 
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata

--- a/models/commons.py
+++ b/models/commons.py
@@ -1,3 +1,7 @@
+# pylint: disable=no-self-argument
+#       - pydantic models are technically class models, so they dont use self.
+# pylint: disable=no-self-use
+#       - pydantic validators use cls instead of self; theyre not instance based
 """
 Holds common modeling classes or utility functions that can be used
 in any single module in `models/`.
@@ -10,7 +14,7 @@ from enum import Enum
 from uuid import uuid4
 from typing import Dict, Any
 
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, validator, Field
 
 
 def generate_uuid4_str() -> str:
@@ -41,6 +45,8 @@ class ExtendedBaseModel(BaseModel):
     Configured version of the pydantic BaseModel that has common
     functions/config values that should be shared accross code.
     """
+    id: str = Field("", alias="_id")  # pylint: disable=invalid-name
+
     class Config:
         use_enum_values = True
 

--- a/models/commons.py
+++ b/models/commons.py
@@ -6,7 +6,11 @@ Any function that achieves the same goal but is written more than once should
 be in this file instead and imported when needed.
 """
 
+from enum import Enum
 from uuid import uuid4
+from typing import Dict, Any
+
+from pydantic import BaseModel, validator
 
 
 def generate_uuid4_str() -> str:
@@ -14,3 +18,50 @@ def generate_uuid4_str() -> str:
     Generates a string representation of a UUID4.
     """
     return str(uuid4())
+
+
+class AutoName(Enum):
+    """
+    Hacky but abstracted-enough solution to the dumb enum naming problem that
+    python has. Basically returns enums in string form when referenced by value
+    """
+
+    # since this is a funky should-be-private method, we have to break
+    # a couple of lint rules
+    # pylint: disable=unused-argument, no-self-argument
+    def _generate_next_value_(name, start, count, last_values):
+        """
+        Returns name of enum rather than assigned value.
+        """
+        return name
+
+
+class ExtendedBaseModel(BaseModel):
+    """
+    Configured version of the pydantic BaseModel that has common
+    functions/config values that should be shared accross code.
+    """
+    class Config:
+        use_enum_values = True
+
+    @validator("id", pre=True, always=True, check_fields=False)
+    def set_id(cls, value) -> str:
+        """
+        Workaround on dynamic default setting for UUID.
+        From: https://github.com/samuelcolvin/pydantic/issues/866
+        """
+        return value or generate_uuid4_str()
+
+    def get_id(self) -> str:
+        """
+        Returns this instance's ID
+        """
+        return self.id
+
+    def dict(self, *args, **kwargs) -> Dict[str, Any]:
+        """
+        Override the base `dict` method in order to get the mongo ID fix
+        """
+        parent_dict = super().dict(*args, **kwargs)
+        parent_dict["_id"] = self.get_id()
+        return parent_dict

--- a/models/events.py
+++ b/models/events.py
@@ -15,9 +15,9 @@ Think of it as strong typing without the verbosity.
 
 These models should be the only places where raw input/output data is changed.
 """
-from enum import Enum, auto
-from typing import List, Any, Dict
-from pydantic import BaseModel, validator, Field
+from enum import auto
+from typing import List
+from pydantic import BaseModel
 import models.users as user_models
 import models.commons as model_commons
 
@@ -62,8 +62,6 @@ class Event(model_commons.ExtendedBaseModel):
     Any changes here can have lots of side effects, as many forms inherit this
     model, thereby sharing fields. Refactor or extend thoughtfully.
     """
-    # alias needed for validator access
-    id: EventId = Field("", alias="_id")  # pylint: disable=invalid-name
     title: str
     description: str
     date: str

--- a/models/events.py
+++ b/models/events.py
@@ -25,23 +25,7 @@ import models.commons as model_commons
 EventId = str
 
 
-class AutoName(Enum):
-    """
-    Hacky but abstracted-enough solution to the dumb enum naming problem that
-    python has. Basically returns enums in string form when referenced by value
-    """
-
-    # since this is a funky should-be-private method, we have to break
-    # a couple of lint rules
-    # pylint: disable=unused-argument, no-self-argument
-    def _generate_next_value_(name, start, count, last_values):
-        """
-        Returns name of enum rather than assigned value.
-        """
-        return name
-
-
-class EventTagEnum(AutoName):
+class EventTagEnum(model_commons.AutoName):
     """
     Enum that holds the different possible types or labels of events.
     """
@@ -52,7 +36,7 @@ class EventTagEnum(AutoName):
     restroom = auto()
 
 
-class EventStatusEnum(AutoName):
+class EventStatusEnum(model_commons.AutoName):
     """
     Holds the different life statuses that events can cycle through.
     """
@@ -70,7 +54,7 @@ class Location(BaseModel):
     longitude: float
 
 
-class Event(BaseModel):
+class Event(model_commons.ExtendedBaseModel):
     """
     Main Event model that should have a 1:1 correlation with the database
     rendition of an event.
@@ -93,33 +77,6 @@ class Event(BaseModel):
     rating: float
     status: EventStatusEnum
     creator_id: user_models.UserId
-
-    # TODO: add landmark flag OR extend into own class
-    # TODO: think about how to handle expiration based on dates
-    class Config:
-        use_enum_values = True
-
-    @validator("id", pre=True, always=True)
-    def set_id(cls, value) -> str:
-        """
-        Workaround on dynamic default setting for UUID.
-        From: https://github.com/samuelcolvin/pydantic/issues/866
-        """
-        return value or model_commons.generate_uuid4_str()
-
-    def get_id(self) -> EventId:
-        """
-        Returns this instance's ID
-        """
-        return self.id
-
-    def dict(self, *args, **kwargs) -> Dict[str, Any]:
-        """
-        Override the base `dict` method in order to get the mongo ID fix
-        """
-        parent_dict = super().dict(*args, **kwargs)
-        parent_dict["_id"] = self.get_id()
-        return parent_dict
 
 
 class EventRegistrationForm(Event):

--- a/models/feedback.py
+++ b/models/feedback.py
@@ -3,27 +3,19 @@
 """
 Holds the (small) models for feedback object to be tied to an event.
 """
-from uuid import uuid4
-from typing import Optional
 from pydantic import BaseModel
+import models.commons as model_commons
 
 FeedbackId = str
 
 
-class Feedback(BaseModel):
+class Feedback(model_commons.ExtendedBaseModel):
     """
     Holds the very simple feedback model that will be
     indexed by ID in an event.
     """
-    _id: Optional[FeedbackId] = str(uuid4())
     event_id: str
     comment: str
-
-    def get_id(self) -> FeedbackId:
-        """
-        Returns the object's protected id.
-        """
-        return self._id
 
 
 class FeedbackQueryResponse(Feedback):

--- a/models/users.py
+++ b/models/users.py
@@ -35,6 +35,7 @@ class User(model_commons.ExtendedBaseModel):
     last_name: str
     email: EmailStr
     password: str
+    user_type: UserTypeEnum
 
     def set_password(self, new_password: str) -> None:
         """

--- a/models/users.py
+++ b/models/users.py
@@ -19,9 +19,10 @@ import models.commons as model_commons
 # type alias for UserID
 UserId = str
 
+class UserTypeEnum(model_commons.AutoEnum):
 
-class User(BaseModel):
-    """
+    class User(model_commons.ExtendedBaseModel):
+        """
     Main top-level user model. Should hold only enough data to be useful,
     as any more can become painful to deal with due to privacy etc.
     """
@@ -31,6 +32,7 @@ class User(BaseModel):
     last_name: str
     email: EmailStr
     password: str
+    user_type: UserTypeEnum
 
     def set_password(self, new_password: str) -> None:
         """
@@ -53,29 +55,6 @@ class User(BaseModel):
             user_pass = self.password[2:-1].encode('utf-8')
         passwords_match = bcrypt.checkpw(pass_to_check, user_pass)
         return passwords_match
-
-    @validator("id", pre=True, always=True)
-    def set_id(cls, value) -> str:
-        """
-        Workaround on dynamic default setting for UUID.
-        From: https://github.com/samuelcolvin/pydantic/issues/866
-        """
-        return value or model_commons.generate_uuid4_str()
-
-    def get_id(self) -> UserId:
-        """
-        Returns the instance's database id
-        """
-        return self.id
-
-    def dict(self, *args, **kwargs) -> Dict[str, Any]:
-        """
-        Override the base `dict` method in order to get the mongo ID fix
-        """
-        parent_dict = super().dict(*args, **kwargs)
-        parent_dict["_id"] = self.get_id()
-        return parent_dict
-
 
 class UserRegistrationForm(User):
     """

--- a/models/users.py
+++ b/models/users.py
@@ -9,30 +9,32 @@ Holds models for the users in the database.
 Should easily extend into a two-user-type system where
 the admin data is different from the regular user data.
 """
-from typing import Dict, Any
+from enum import auto
+from typing import Dict
 
 import bcrypt
-from pydantic import EmailStr, BaseModel, Field, validator
+from pydantic import EmailStr, BaseModel
 
 import models.commons as model_commons
 
 # type alias for UserID
 UserId = str
 
-class UserTypeEnum(model_commons.AutoEnum):
 
-    class User(model_commons.ExtendedBaseModel):
-        """
+class UserTypeEnum(model_commons.AutoName):
+    PUBLIC_USER = auto()
+    ADMIN = auto()
+
+
+class User(model_commons.ExtendedBaseModel):
+    """
     Main top-level user model. Should hold only enough data to be useful,
     as any more can become painful to deal with due to privacy etc.
     """
-    # alias needed for validator access
-    id: UserId = Field("", alias="_id")  # pylint: disable=invalid-name
     first_name: str
     last_name: str
     email: EmailStr
     password: str
-    user_type: UserTypeEnum
 
     def set_password(self, new_password: str) -> None:
         """
@@ -55,6 +57,7 @@ class UserTypeEnum(model_commons.AutoEnum):
             user_pass = self.password[2:-1].encode('utf-8')
         passwords_match = bcrypt.checkpw(pass_to_check, user_pass)
         return passwords_match
+
 
 class UserRegistrationForm(User):
     """

--- a/models/users.py
+++ b/models/users.py
@@ -3,17 +3,16 @@
 # pylint: disable=no-self-use
 #       - pydantic validators use cls instead of self; theyre not instance based
 # pylint: disable=no-name-in-module; see https://github.com/samuelcolvin/pydantic/issues/1961
+# pylint: disable=unsubscriptable-object
+#       - pylint bug with optional
 """
-Holds models for the users in the database.
-
-Should easily extend into a two-user-type system where
-the admin data is different from the regular user data.
+Holds models for admin-only operations and users.
 """
 from enum import auto
-from typing import Dict
+from typing import Dict, Optional
 
 import bcrypt
-from pydantic import EmailStr, BaseModel
+from pydantic import EmailStr, BaseModel, root_validator
 
 import models.commons as model_commons
 
@@ -60,10 +59,16 @@ class User(model_commons.ExtendedBaseModel):
         return passwords_match
 
 
-class UserRegistrationForm(User):
+class UserRegistrationForm(BaseModel):
     """
     Client-facing user registration form.
+
+    Only carries the necessary client-facing data, hiding the `User` internals.
     """
+    first_name: str
+    last_name: str
+    email: EmailStr
+    password: str
 
 
 class UserRegistrationResponse(BaseModel):
@@ -80,20 +85,47 @@ class UserIdentifier(BaseModel):
     This gives us a lot more freedom in how we actually implement things like
     queries, as well as login/signup ops.
     """
-    email: EmailStr
+    email: Optional[EmailStr]
+    user_id: Optional[UserId]
+
+    @root_validator()
+    def check_at_least_one_identifier(cls, values):
+        """
+        Since the identifiers are typed as Optionals, we need to make sure
+        that at _least_ one form of identification is passed in.
+        """
+        has_non_null_entries = all(values.values())
+
+        if has_non_null_entries:
+            return values
+
+        message = "At least one type of identifier must be specified."
+        raise ValueError(message)
 
     def get_database_query(self) -> Dict[str, str]:
         """
-        Returns a query dict that always has at least one valid identifier.
+        Generates a valid database query dict from the instance's information.
         """
-        return {"email": self.email}
+        self_key_val_pairs = self.dict().items()
+
+        # only use non-null values for identifier
+        query_dict = {key: val for key, val in self_key_val_pairs if val}
+
+        # mongo uses `_id` for it's uuid field
+        if "user_id" in query_dict:
+            query_dict["_id"] = query_dict.pop("user_id")
+
+        return query_dict
 
 
-class UserInfoQueryResponse(User):
+class UserInfoQueryResponse(BaseModel):
     """
     Response for a user data query, which should be all
     of the user's public-facing information.
     """
+    first_name: str
+    last_name: str
+    email: EmailStr
 
 
 class UserLoginForm(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,9 +73,9 @@ def registered_user(
     """
     user_data = get_user_from_user_reg_form(user_registration_form)
 
-    user_id = async_to_sync(user_utils.register_user)(user_registration_form)
     # user ID auto-instanciates so we reassign it to the actual ID
-    user_data.id = user_id  # pylint: disable=invalid-name
+    user_id = async_to_sync(user_utils.register_user)(user_registration_form)
+    user_data.id = user_id
 
     return user_data
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,20 +62,33 @@ def run_around_tests():
 
 
 @pytest.fixture(scope='function')
-def registered_user() -> user_models.User:
+def registered_user(
+    user_registration_form: user_models.UserRegistrationForm
+) -> user_models.User:
     """
     Fixture that generates a random valid user and registers it directly to
     the database through the `util` method.
 
     Returns the original user object.
     """
-    user_data = generate_random_user()
-    original_user_password = user_data.password
-    async_to_sync(user_utils.register_user)(user_data)
+    user_data = get_user_from_user_reg_form(user_registration_form)
 
-    # revert password post-register to the pre-hash version
-    user_data.password = original_user_password
+    user_id = async_to_sync(user_utils.register_user)(user_registration_form)
+    # user ID auto-instanciates so we reassign it to the actual ID
+    user_data.id = user_id  # pylint: disable=invalid-name
+
     return user_data
+
+
+def get_user_from_user_reg_form(
+        user_reg_form: user_models.UserRegistrationForm) -> user_models.User:
+    """
+    Helper method that correctly casts a `UserRegistrationForm` into
+    a valid `User` object and returns it.
+    """
+    user_type = user_models.UserTypeEnum.PUBLIC_USER
+    user_object = user_models.User(**user_reg_form.dict(), user_type=user_type)
+    return user_object
 
 
 @pytest.fixture(scope='function')
@@ -119,9 +132,10 @@ def get_identifier_dict_from_user(
     Takes data from a registered user and returns a dict with
     user identifier data to be passed as a json dict
     """
-    def _user_data_to_json(user_data: user_models.User):
+    def _user_data_to_json(user_data: user_models.User) -> Dict[str, Any]:
         user_email = user_data.email
-        return {"email": user_email}
+        user_id = user_data.get_id()
+        return {"email": user_email, "user_id": user_id}
 
     return _user_data_to_json
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,7 @@ def generate_random_user() -> user_models.User:
         "last_name": fake.last_name(),
         "email": fake.email(),
         "password": fake.password(),
+        "user_type": get_random_enum_member_value(user_models.UserTypeEnum),
     }
     return user_models.User(**user_data)
 

--- a/tests/test_attempt_user_login.py
+++ b/tests/test_attempt_user_login.py
@@ -1,12 +1,18 @@
 # pylint: disable=no-self-use
 #       - pylint test classes must pass self, even if unused.
+# pylint: disable=redefined-outer-name
+#       - calling an internal fixture; pylint does not like this.
+# pylint: disable=unsubscriptable-object
+#       - false positive lint; pylint not updated to use advanced type hints yet
+#       - pylint test classes must pass self, even if unused.
 # pylint: disable=logging-fstring-interpolation
 #       - honestly just annoying to use lazy(%) interpolation.
 """
 Endpoint testing for attempting a user login
 """
 import logging
-from typing import Dict
+from typing import Dict, Callable, Any
+import pytest
 from fastapi.testclient import TestClient
 from requests.models import Response as HTTPResponse
 import models.users as user_models
@@ -29,14 +35,27 @@ def get_user_login_endpoint_url() -> str:
     return "/users/login"
 
 
-def get_user_login_json_data(user: user_models.User) -> Dict[str, str]:
+@pytest.fixture
+def get_login_request_from_user(
+    get_identifier_dict_from_user: Callable[[user_models.User], Dict[str, Any]]
+) -> Dict[str, Any]:
     """
-    Returns the url params needed to login the given user object
-    through the user login endpoint.
+    Internal fixture that returns a `Callable` function which creates
+    and returns a valid json dict for the login endpoint given a user object.
     """
-    identifier = {"email": user.email}
-    password = user.password
-    return {"identifier": identifier, "password": password}
+    def __get_login_request_from_user(
+            user: user_models.User) -> Dict[str, Any]:
+        """
+        Returned internal method that takes in a user object and uses
+        the `get_identifier_dict_from_user` fixture in order to create
+        and return the correct json data dict for the endpoint.
+        """
+        identifier_dict = get_identifier_dict_from_user(user)
+        password = user.password
+        return {"identifier": identifier_dict, "password": password}
+
+    return __get_login_request_from_user
+
 
 def check_user_login_response_valid(response: HTTPResponse) -> bool:
     """
@@ -59,23 +78,29 @@ def check_jwt_valid(response: HTTPResponse) -> bool:
 
 
 class TestAttemptUserLogin:
-    def test_correct_pass(self, registered_user: user_models.User):
+    def test_correct_pass(
+        self, registered_user: user_models.User,
+        get_login_request_from_user: Callable[[user_models.User], Dict[str,
+                                                                       Any]]):
         """
         Tries to login an existing user with existing.
         Expects success and 200 response code
         """
         request_url = get_user_login_endpoint_url()
-        json_payload = get_user_login_json_data(registered_user)
+        json_payload = get_login_request_from_user(registered_user)
         response = client.post(request_url, json=json_payload)
         assert check_user_login_response_valid(response)
 
-    def test_incorrect_pass(self, registered_user: user_models.User):
+    def test_incorrect_pass(
+        self, registered_user: user_models.User,
+        get_login_request_from_user: Callable[[user_models.User], Dict[str,
+                                                                       Any]]):
         """
         Tries to login with a user and incorrect pass.
         Expects failure and a 422 response code
         """
         request_url = get_user_login_endpoint_url()
-        json_payload = get_user_login_json_data(registered_user)
+        json_payload = get_login_request_from_user(registered_user)
         false_pass = 'aaaaaaaaaa'
         assert json_payload.get("password") != false_pass
         json_payload["password"] = false_pass
@@ -83,13 +108,17 @@ class TestAttemptUserLogin:
         assert not check_user_login_response_valid(response)
         assert response.status_code == 422
 
-    def test_nonexisting_user(self, unregistered_user: user_models.User):
+    def test_nonexisting_user(
+        self, unregistered_user: user_models.User,
+        get_login_request_from_user: Callable[[user_models.User], Dict[str,
+                                                                       Any]]):
         """
         Tries to login with a user that isn't in database.
         Expects failure and a 404 response code
         """
         request_url = get_user_login_endpoint_url()
-        nonexistent_user_payload = get_user_login_json_data(unregistered_user)
+        nonexistent_user_payload = get_login_request_from_user(
+            unregistered_user)
 
         response = client.post(request_url, json=nonexistent_user_payload)
         assert not check_user_login_response_valid(response)

--- a/util/users.py
+++ b/util/users.py
@@ -19,16 +19,28 @@ async def register_user(
     """
     Register a user registration form to the database and return it's user ID.
     """
-    pre_hash_user_password = user_reg_form.password
-    user_reg_form.set_password(pre_hash_user_password)
-    # cast input form (python class) -> dictionary (become JSON eventually)
-    form_dict = user_reg_form.dict()
+    user_object = await get_valid_user_from_reg_form(user_reg_form)
 
     # insert id into column
-    users_collection().insert_one(form_dict)
+    users_collection().insert_one(user_object.dict())
 
     # return user_id if success
-    return form_dict["_id"]
+    return user_object.get_id()
+
+
+async def get_valid_user_from_reg_form(
+        user_reg_form: user_models.UserRegistrationForm) -> user_models.User:
+    """
+    Casts an incoming user registration form into a `User` object,
+    effectively validating the user, and setting the password.
+    """
+    user_type = user_models.UserTypeEnum.PUBLIC_USER
+    user_object = user_models.User(**user_reg_form.dict(), user_type=user_type)
+
+    pre_hash_user_password = user_reg_form.password
+    user_object.set_password(pre_hash_user_password)
+
+    return user_object
 
 
 async def get_user_info_by_identifier(


### PR DESCRIPTION
In order to add admin capabilities and extend the existing user models/code, a heavy refactor was needed to de-couple some existing data and create room for user-type distinctions.

The PR code can really be split into two: 
- The addition of the `UserTypeEnum` into the `User` model, and the implementation surrounding that change
- The refactoring of other user models (`User`, `UserRegistrationForm`, `UserIdentifier`, etc.) as well as the extraction of the configured `BaseModel` class -> `models.commons.ExtendedBaseModel` class.

The refactoring was simple but it's important to now understand that all of the data is split. This means that most classes/forms do NOT inherit from `User` any longer. 

This removes the convenience of the polymorphic methods we were using up to now, but in return gives us a much stronger and more deliberate way to move and validate incoming/outgoing data (remember the trade off: abstraction for explicit control). 

The minor details of this PR include a small fix to some testing fixtures in order to make the new code run and work. These test refactors/fixes were INCREDIBLY easy due to our rock-solid fixture system. Really really excellent health indicator!