### PR TITLE
Implementation of new event data

### DIFF
--- a/models/events.py
+++ b/models/events.py
@@ -16,8 +16,9 @@ Think of it as strong typing without the verbosity.
 These models should be the only places where raw input/output data is changed.
 """
 from enum import auto
-from typing import List
 from datetime import datetime
+from typing import List, Optional
+
 from pydantic import BaseModel
 import models.users as user_models
 import models.commons as model_commons
@@ -66,13 +67,14 @@ class Event(model_commons.ExtendedBaseModel):
     """
     title: str
     description: str
-    date_time_start: str
-    date_time_end: str
+    date_time_start: datetime
+    date_time_end: datetime
     tags: List[EventTagEnum]
     location: Location
     max_capacity: int
     public: bool
-    attending: List[user_models.UserId]
+    comment_ids: List[str] = []
+    attending: List[user_models.UserId] = []
     status: EventStatusEnum = EventStatusEnum.active
     links: List[str]
     creator_id: user_models.UserId
@@ -95,6 +97,9 @@ class EventRegistrationForm(BaseModel):
     max_capacity: int
     links: Optional[List[str]] = []
     creator_id: user_models.UserId
+
+    class Config:
+        use_enum_values = True
 
 
 class EventRegistrationResponse(BaseModel):
@@ -132,6 +137,7 @@ class EventQueryResponse(BaseModel):
     max_capacity: int
     public: bool
     attending: List[user_models.UserId]
+    comment_ids: List[str]
     status: EventStatusEnum
     links: List[str]
     creator_id: user_models.UserId

--- a/models/events.py
+++ b/models/events.py
@@ -17,6 +17,7 @@ These models should be the only places where raw input/output data is changed.
 """
 from enum import auto
 from typing import List
+from datetime import datetime
 from pydantic import BaseModel
 import models.users as user_models
 import models.commons as model_commons
@@ -50,6 +51,7 @@ class Location(BaseModel):
     """
     Simple tuple-like to group lat,long into a logical pairing.
     """
+    title: str
     latitude: float
     longitude: float
 
@@ -64,23 +66,35 @@ class Event(model_commons.ExtendedBaseModel):
     """
     title: str
     description: str
-    date: str
-    tag: EventTagEnum
+    date_time_start: str
+    date_time_end: str
+    tags: List[EventTagEnum]
     location: Location
     max_capacity: int
     public: bool
-    attending: List[user_models.User]
-    upvotes: int
-    comment_ids: List[str]
-    rating: float
-    status: EventStatusEnum
+    attending: List[user_models.UserId]
+    status: EventStatusEnum = EventStatusEnum.active
+    links: List[str]
     creator_id: user_models.UserId
 
 
-class EventRegistrationForm(Event):
+class EventRegistrationForm(BaseModel):
     """
     Form that represents an event registration.
+
+    Has only the necessary client-facing data needed to create
+    an event in the database.
     """
+    title: str
+    description: str
+    date_time_start: datetime
+    date_time_end: datetime
+    tags: List[EventTagEnum]
+    public: bool  # TODO: this has to actually be handled
+    location: Location
+    max_capacity: int
+    links: Optional[List[str]] = []
+    creator_id: user_models.UserId
 
 
 class EventRegistrationResponse(BaseModel):
@@ -103,12 +117,25 @@ class ListOfEvents(BaseModel):
     events: List[Event]
 
 
-class EventQueryResponse(Event):
+class EventQueryResponse(BaseModel):
     """
     This is user-facing (i.e. public) data type for an event.
 
     Shouldn't hold any logistic/serverside details for events if possible.
     """
+    title: str
+    description: str
+    date_time_start: str
+    date_time_end: str
+    tags: List[EventTagEnum]
+    location: Location
+    max_capacity: int
+    public: bool
+    attending: List[user_models.UserId]
+    status: EventStatusEnum
+    links: List[str]
+    creator_id: user_models.UserId
+    event_id: EventId
 
 
 # NOTE: The following few models seems really stupid but returning

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,10 @@ pytest `conftest.py` file that holds global fixtures for tests
 import os
 import random
 import logging
-import datetime
+from datetime import datetime, timedelta
 from enum import Enum
 from uuid import uuid4
-from typing import List, Callable, Dict, Any
+from typing import List, Callable, Dict, Any, Tuple
 
 import pytest
 from faker import Faker
@@ -240,29 +240,53 @@ def event_registration_form() -> event_models.EventRegistrationForm:
 
 def generate_random_event() -> event_models.Event:
     """
-    Uses a fake data generator to generate a unique
+    Uses a fake data generator to generate a unique, public,
     and valid event object.
     """
     fake = Faker()
+    start_time, end_time = get_valid_date_range_from_now()
+
+    event_tags = [
+        get_random_enum_member_value(event_models.EventTagEnum)
+        for _ in range(5)
+    ]
+
     event_data = {
         "title": fake.text(),
         "description": fake.text(),
-        "date": str(datetime.datetime.now()),
-        "tag": get_random_enum_member_value(event_models.EventTagEnum),
+        "date_time_start": str(start_time),
+        "date_time_end": str(end_time),
+        "tags": event_tags,
         "location": {
+            "title": fake.text(),
             "latitude": float(fake.latitude()),
             "longitude": float(fake.longitude()),
         },
         "max_capacity": random.randint(1, 100),
-        "public": random.choice([True, False]),
+        "public": True,
         "attending": [],
-        "upvotes": 0,
         "comment_ids": [],
-        "rating": random.randint(0, 5),
         "status": get_random_enum_member_value(event_models.EventStatusEnum),
+        "links": [fake.text() for _ in range(5)],
         "creator_id": fake.uuid4()
     }
     return event_models.Event(**event_data)
+
+
+def get_valid_date_range_from_now() -> Tuple[datetime, datetime]:
+    """
+    Generates a tuple of valid datetime where the first datetime
+    is `datetime.now()` and the second is a random, valid range after
+    the first one.
+    """
+    fake = Faker()
+    datetime_from_start_range = lambda start: fake.date_time_between_dates(
+        start, start + timedelta(days=10))
+
+    start_datetime = datetime_from_start_range(datetime.now())
+    end_datetime = datetime_from_start_range(start_datetime)
+
+    return start_datetime, end_datetime
 
 
 @pytest.fixture(scope="function")

--- a/tests/test_event_registration.py
+++ b/tests/test_event_registration.py
@@ -9,6 +9,7 @@
 Endpoint tests for registering events.
 """
 import logging
+import datetime
 from typing import Dict, Any
 
 from fastapi.testclient import TestClient
@@ -46,8 +47,13 @@ def get_json_from_event_reg_form(
         event_form: event_models.EventRegistrationForm) -> Dict[str, Any]:
     """
     Creates and returns a valid json payload from an event registration form
+
+    Turns all `datetimes` to `str(datetimes)` in place so they can be
+    JSON serialized.
     """
     json_dict = event_form.dict()
+    set_datetimes_to_str_in_place(json_dict)
+
     return json_dict
 
 
@@ -61,7 +67,20 @@ def get_invalid_json_from_reg_form(
     values = list(event_dict.values())[::-1]
     for key, value in zip(event_dict.keys(), values):
         event_dict[key] = value
+
+    # we still have to make datetimes valid
+    set_datetimes_to_str_in_place(event_dict)
+
     return event_dict
+
+
+def set_datetimes_to_str_in_place(json_dict: Dict[str, Any]) -> None:
+    """
+    Sets all `datetime` instances to `str(datetime)` in-place.
+    """
+    for key, value in json_dict.items():
+        if isinstance(value, datetime.datetime):
+            json_dict[key] = str(value)
 
 
 class TestRegisterEvent:

--- a/util/events.py
+++ b/util/events.py
@@ -35,7 +35,9 @@ async def get_event_from_event_reg_form(
     """
     Returns a validated Event from a event registration form
     """
-    return event_models.Event(**event_reg_form.dict())
+    event_reg_form_dict = event_reg_form.dict()
+    valid_event = event_models.Event(**event_reg_form_dict)
+    return valid_event
 
 
 async def get_event_by_id(


### PR DESCRIPTION
`Event` and `EventRegistrationForm` models now match what frontend has.

Involved minor refactorings and some fixes to the conftest fixtures we had, but since it's all parameterized, it was surprisingly easy and simple to fix. 

Other notes: 
- `EventRegistrationForm` no longer inherits from `Event` (this makes it easier to de-couple what we need from the client and what the database has)
- `EventQueryResponse` also no longer inherits from `Event`