### PR TITLE
implement auth tokens on endpoints + add test for registering feedback

### DIFF
--- a/models/exceptions.py
+++ b/models/exceptions.py
@@ -82,10 +82,21 @@ class InvalidPasswordException(HTTPException):
 
 class InvalidAuthHeaderException(HTTPException):
     """
-    Default for empty header which expects a JWK string
+    Default for empty header which expects a JWT string
     that raises a 401
     """
     def __init__(self, detail: Optional[str] = None):
         if not detail:
             detail = "Invalid authorization token in header"
+        super().__init__(status_code=401, detail=detail)
+
+
+class UnauthorizedIdentifierData(HTTPException):
+    """
+    Raised when the user data passed in does not match the
+    data in the authorization token header.
+    """
+    def __init__(self, detail: Optional[str] = None):
+        if not detail:
+            detail = "Invalid identifier data: does not match auth header token"
         super().__init__(status_code=401, detail=detail)

--- a/models/feedback.py
+++ b/models/feedback.py
@@ -20,20 +20,26 @@ class Feedback(model_commons.ExtendedBaseModel):
     creator_id: user_models.UserId
 
 
-class FeedbackQueryResponse(Feedback):
+class FeedbackQueryResponse(BaseModel):
     """
     Model for all public facing data from a feedback document in the database
     """
+    event_id: str
+    comment: str
+    creator_id: user_models.UserId
 
 
-class FeedbackRegistrationRequest(Feedback):
+class FeedbackRegistrationRequest(BaseModel):
     """
     Client facing registration form for feedback.
     """
+    event_id: str
+    comment: str
+    creator_id: user_models.UserId
 
 
 class FeedbackRegistrationResponse(BaseModel):
     """
     Response for a successful feedback registration.
     """
-    feedback_id: str
+    feedback_id: FeedbackId

--- a/models/feedback.py
+++ b/models/feedback.py
@@ -4,6 +4,7 @@
 Holds the (small) models for feedback object to be tied to an event.
 """
 from pydantic import BaseModel
+import models.users as user_models
 import models.commons as model_commons
 
 FeedbackId = str
@@ -16,6 +17,7 @@ class Feedback(model_commons.ExtendedBaseModel):
     """
     event_id: str
     comment: str
+    creator_id: user_models.UserId
 
 
 class FeedbackQueryResponse(Feedback):

--- a/models/users.py
+++ b/models/users.py
@@ -15,8 +15,9 @@ from typing import Dict, Optional
 import bcrypt
 from pydantic import EmailStr, BaseModel, root_validator, validator
 
-import models.commons as model_commons
+from models import exceptions
 import models.images as image_models
+import models.commons as model_commons
 
 # type alias for UserID
 UserId = str
@@ -123,6 +124,20 @@ class UserIdentifier(BaseModel):
             query_dict["_id"] = query_dict.pop("user_id")
 
         return query_dict
+
+    def check_user_id_matches_or_error(self, user_id: UserId) -> None:
+        """
+        Checks if the `UserId` passed in matches the `user_id` field
+        for the identifier. If not, raises a 401 authentication error,
+        else returns None.
+
+        If no `user_id` is present, raises a ValueError.
+        """
+        if not self.user_id:
+            raise ValueError("No user_id present in identifier")
+
+        if not self.user_id == user_id:
+            raise exceptions.UnauthorizedIdentifierData
 
 
 class UserUpdateForm(BaseModel):

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -15,6 +15,6 @@ router = APIRouter()
     tags=["Auth"],
     status_code=204,
 )
-async def validate_token(token_str: str = Depends(
-    utils.get_auth_token_from_header)):
-    del token_str  # unused var
+async def validate_token(user_id_from_token: str = Depends(
+    utils.get_user_id_from_header_and_check_existence)):
+    del user_id_from_token  # unused var

--- a/routes/events.py
+++ b/routes/events.py
@@ -36,9 +36,9 @@ async def register_event(
         2. send the data from to the `util.register_event` method
         3. return the `event_id` from the inserted document to the client
     """
+    await utils.check_user_id_matches_reg_form(form, user_id_from_token)
     # send the form data and DB instance to util.events.register_event
-    event_registration_response = await utils.register_event(
-        form, user_id_from_token)
+    event_registration_response = await utils.register_event(form)
 
     # return response in reponse model
     return event_registration_response

--- a/routes/events.py
+++ b/routes/events.py
@@ -5,11 +5,14 @@ As with all files in `routes/`, the endpoints here should do as little actual
 data handling as possible, handing it off to the handler in `util/` as soon
 as possible.
 """
-from fastapi import APIRouter
+from typing import Dict, Any
+from fastapi import APIRouter, Depends
 
 from models import events as models
 from docs import events as docs
 from util import events as utils
+
+import util.auth as auth_utils
 
 router = APIRouter()
 
@@ -22,7 +25,10 @@ router = APIRouter()
     tags=["Events"],
     status_code=201,
 )
-async def register_event(form: models.EventRegistrationForm):
+async def register_event(
+    form: models.EventRegistrationForm,
+    user_id_from_token: str = Depends(
+        auth_utils.get_user_id_from_header_and_check_existence)):
     """
     Main endpoint handler for registering an event.
 
@@ -32,7 +38,8 @@ async def register_event(form: models.EventRegistrationForm):
         3. return the `event_id` from the inserted document to the client
     """
     # send the form data and DB instance to util.events.register_event
-    event_registration_response = await utils.register_event(form)
+    event_registration_response = await utils.register_event(
+        form, user_id_from_token)
 
     # return response in reponse model
     return event_registration_response

--- a/routes/events.py
+++ b/routes/events.py
@@ -5,7 +5,6 @@ As with all files in `routes/`, the endpoints here should do as little actual
 data handling as possible, handing it off to the handler in `util/` as soon
 as possible.
 """
-from typing import Dict, Any
 from fastapi import APIRouter, Depends
 
 from models import events as models

--- a/routes/feedback.py
+++ b/routes/feedback.py
@@ -9,12 +9,14 @@ actual union of events and feedback to code in `util/` files to remain
 flexible and have this code be implementation-agnostic.
 """
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
-from models import feedback as feedback_models
-from models import events as event_models
-from docs import feedback as docs
 import util.feedback as utils
+import util.auth as auth_utils
+from docs import feedback as docs
+from models import exceptions
+from models import events as event_models
+from models import feedback as feedback_models
 
 router = APIRouter()
 ROUTER_TAG = "Feedback"
@@ -27,15 +29,18 @@ ROUTER_TAG = "Feedback"
     tags=[ROUTER_TAG],
     status_code=204,
 )
-async def delete_feedback(event_id: event_models.EventId,
-                          feedback_id: feedback_models.FeedbackId):
+async def delete_feedback(
+    event_id: event_models.EventId,
+    feedback_id: feedback_models.FeedbackId,
+    user_id_from_token: str = Depends(
+        auth_utils.get_user_id_from_header_and_check_existence)):
     """
     Endpoint for deleting feedback for an event given IDs for both.
 
     Returns nothing if it is successful (204).
     """
     # perform deletion
-    await utils.delete_feedback(event_id, feedback_id)
+    await utils.delete_feedback(event_id, feedback_id, user_id_from_token)
 
 
 @router.post(
@@ -46,10 +51,16 @@ async def delete_feedback(event_id: event_models.EventId,
     tags=[ROUTER_TAG],
     status_code=201,
 )
-async def add_feedback(form: feedback_models.FeedbackRegistrationRequest):
+async def add_feedback(
+    form: feedback_models.FeedbackRegistrationRequest,
+    user_id_from_token: str = Depends(
+        auth_utils.get_user_id_from_header_and_check_existence)):
     """
     Endpoint to register a feedback to an event.
     """
+    if user_id_from_token != form.creator_id:
+        raise exceptions.UnauthorizedIdentifierData
+
     # send the form data and DB instance to util.users.register_user
     feedback_id = await utils.register_feedback(form)
 

--- a/routes/images.py
+++ b/routes/images.py
@@ -2,11 +2,12 @@
 Endpoint routers for Images.
 """
 import io
-from fastapi import APIRouter, File, UploadFile
 from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, File, UploadFile, Depends
 
 from docs import images as docs
 from util import images as utils
+from util import auth as auth_utils
 from models import images as models
 
 router = APIRouter()
@@ -18,7 +19,11 @@ router = APIRouter()
              summary=docs.image_upload_summ,
              tags=["Images"],
              status_code=201)
-async def upload_file(file: UploadFile = File(...)):
+async def upload_file(
+        file: UploadFile = File(...),
+        user_id_from_token: str = Depends(
+            auth_utils.get_user_id_from_header_and_check_existence)):
+    del user_id_from_token  # unused var
     image_id = await utils.image_upload(file)
     return models.ImageUploadResponse(image_id=image_id)
 

--- a/routes/users.py
+++ b/routes/users.py
@@ -4,10 +4,11 @@ Endpoint routers for users.
 Eventually might need to handle auth here as well, so write code as if
 that was an upcoming feature.
 """
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from models import users as models
 from docs import users as docs
 import util.users as utils
+import util.auth as auth_utils
 
 router = APIRouter()
 
@@ -37,7 +38,11 @@ async def register_user(form: models.UserRegistrationForm):
     tags=["Users"],
     status_code=204,
 )
-async def delete_user(identifier: models.UserIdentifier):
+async def delete_user(
+    identifier: models.UserIdentifier,
+    user_id_from_token: str = Depends(
+        auth_utils.get_user_id_from_header_and_check_existence)):
+    identifier.check_user_id_matches_or_error(user_id_from_token)
     await utils.delete_user(identifier)
 
 
@@ -68,5 +73,11 @@ async def login_user(login_form: models.UserLoginForm):
               summary=docs.update_user_summ,
               tags=["Users"],
               status_code=200)
-async def update_user(update_form: models.UserUpdateForm):
+async def update_user(
+    update_form: models.UserUpdateForm,
+    user_id_from_token: str = Depends(
+        auth_utils.get_user_id_from_header_and_check_existence)):
+    identifier = update_form.identifier
+    identifier.check_user_id_matches_or_error(user_id_from_token)
+
     return await utils.update_user(update_form)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 # pylint: disable=redefined-outer-name
 #       - this is how we use fixtures internally so this throws false positives
+# pylint: disable=unsubscriptable-object
+#       - this is actually a pylint bug that hasn't been resolved.
 """
 pytest `conftest.py` file that holds global fixtures for tests
 """
@@ -482,7 +484,7 @@ def invalid_image_data_byte_buffer() -> bytes:
 
 
 @pytest.fixture(scope="function")
-def get_valid_header_token_dict_from_user(
+def get_valid_header_token_dict_from_user(  #pylint: disable=invalid-name
     get_valid_header_token_dict_from_user_id: Callable[[user_models.UserId],
                                                        Dict[str, Any]]
 ) -> Callable[[user_models.User], Dict[str, Any]]:
@@ -498,19 +500,19 @@ def get_valid_header_token_dict_from_user(
         """
         user_id = user.get_id()
         header_dict = get_valid_header_token_dict_from_user_id(user_id)
-        return headers_dict
+        return header_dict
 
     return _generate_header_dict_for_user
 
 
 @pytest.fixture(scope="function")
-def get_valid_header_token_dict_from_user_id(
+def get_valid_header_token_dict_from_user_id(  #pylint: disable=invalid-name
 ) -> Callable[[user_models.UserId], Dict[str, Any]]:
     """
     Returns an inner function that creates a valid header token dict
     from a valid user id and returns it
     """
-    def _generate_header_dict_for_user_id(
+    def _generate_header_for_user_id(
             user_id: user_models.UserId) -> Dict[str, Any]:
         """
         Creates an encoded token string from the user's ID and
@@ -523,7 +525,7 @@ def get_valid_header_token_dict_from_user_id(
         headers_dict = {"token": encoded_token_str}
         return headers_dict
 
-    return _generate_header_dict_for_user_id
+    return _generate_header_for_user_id
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -300,7 +300,8 @@ def event_reg_form_factory(
         """
         registered_user = registered_user_factory()
         event_data = generate_random_event(user=registered_user).dict()
-        return event_models.EventRegistrationForm(**event_data)
+        event_reg_form = event_models.EventRegistrationForm(**event_data)
+        return event_reg_form
 
     return _registration_form_factory
 
@@ -342,7 +343,7 @@ def generate_random_event(
         "status": get_random_enum_member_value(event_models.EventStatusEnum),
         "links": [fake.text() for _ in range(5)],
         "image_ids": [fake.uuid4() for _ in range(5)],
-        "creator_id": fake.uuid4()
+        "creator_id": creator_id
     }
     return event_models.Event(**event_data)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -484,8 +484,8 @@ def invalid_image_data_byte_buffer() -> bytes:
 
 
 @pytest.fixture(scope="function")
-def get_valid_header_token_dict_from_user(  #pylint: disable=invalid-name
-    get_valid_header_token_dict_from_user_id: Callable[[user_models.UserId],
+def get_header_dict_from_user(
+    get_header_dict_from_user_id: Callable[[user_models.UserId],
                                                        Dict[str, Any]]
 ) -> Callable[[user_models.User], Dict[str, Any]]:
     """
@@ -499,14 +499,14 @@ def get_valid_header_token_dict_from_user(  #pylint: disable=invalid-name
         wraps it in a dict with a valid key, returning the result.
         """
         user_id = user.get_id()
-        header_dict = get_valid_header_token_dict_from_user_id(user_id)
+        header_dict = get_header_dict_from_user_id(user_id)
         return header_dict
 
     return _generate_header_dict_for_user
 
 
 @pytest.fixture(scope="function")
-def get_valid_header_token_dict_from_user_id(  #pylint: disable=invalid-name
+def get_header_dict_from_user_id(
 ) -> Callable[[user_models.UserId], Dict[str, Any]]:
     """
     Returns an inner function that creates a valid header token dict
@@ -526,6 +526,33 @@ def get_valid_header_token_dict_from_user_id(  #pylint: disable=invalid-name
         return headers_dict
 
     return _generate_header_for_user_id
+
+
+@pytest.fixture(scope="function")
+def nonexistent_user_header_dict(
+    unregistered_user: user_models.User,
+    get_header_dict_from_user: Callable[[user_models.User],
+                                                    Dict[str, Any]]
+) -> Dict[str, Any]:
+    """
+    Creates and returns a valid auth header with the user id of
+    a nonexistent user.
+    """
+    return get_header_dict_from_user(unregistered_user)
+
+
+@pytest.fixture(scope="function")
+def valid_header_dict_with_user_id(
+    registered_user: user_models.User,
+    get_header_dict_from_user: Callable[[user_models.User],
+                                                    Dict[str, Any]]
+) -> Dict[str, Any]:
+    """
+    Uses fixtures to generate and register a valid user, then
+    create a valid header dict from it's data, returning the
+    final header dict.
+    """
+    return get_header_dict_from_user(registered_user)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,8 @@ import models.auth as auth_models
 
 import util.users as user_utils
 import util.events as event_utils
-import util.feedback as feedback_utils
 import util.images as image_utils
+import util.feedback as feedback_utils
 
 
 # startup process
@@ -46,16 +46,16 @@ def pytest_configure(config):
     del config  # unused variable
 
 
-def pytest_unconfigure(config):  # pytest: disable=unused-argument
+def pytest_unconfigure(config):
     """
     Shutdown process for tests, mostly involving the wiping of database
     documents and resetting the testing environment flag.
     """
-    del config  # unused variable
     global_database_instance = _get_global_database_instance()
     global_database_instance.delete_test_database()
     global_database_instance.close_client_connection()
     os.environ['_called_from_test'] = 'False'
+    del config  # unused variable
 
 
 @pytest.fixture(autouse=True)
@@ -485,8 +485,8 @@ def invalid_image_data_byte_buffer() -> bytes:
 
 @pytest.fixture(scope="function")
 def get_header_dict_from_user(
-    get_header_dict_from_user_id: Callable[[user_models.UserId],
-                                                       Dict[str, Any]]
+    get_header_dict_from_user_id: Callable[[user_models.UserId], Dict[str,
+                                                                      Any]]
 ) -> Callable[[user_models.User], Dict[str, Any]]:
     """
     Returns an inner function that creates a valid header token dict
@@ -531,8 +531,7 @@ def get_header_dict_from_user_id(
 @pytest.fixture(scope="function")
 def nonexistent_user_header_dict(
     unregistered_user: user_models.User,
-    get_header_dict_from_user: Callable[[user_models.User],
-                                                    Dict[str, Any]]
+    get_header_dict_from_user: Callable[[user_models.User], Dict[str, Any]]
 ) -> Dict[str, Any]:
     """
     Creates and returns a valid auth header with the user id of
@@ -543,16 +542,16 @@ def nonexistent_user_header_dict(
 
 @pytest.fixture(scope="function")
 def valid_header_dict_with_user_id(
-    registered_user: user_models.User,
-    get_header_dict_from_user: Callable[[user_models.User],
-                                                    Dict[str, Any]]
+    registered_user_factory: Callable[[], user_models.User],
+    get_header_dict_from_user: Callable[[user_models.User], Dict[str, Any]]
 ) -> Dict[str, Any]:
     """
     Uses fixtures to generate and register a valid user, then
     create a valid header dict from it's data, returning the
     final header dict.
     """
-    return get_header_dict_from_user(registered_user)
+    user = registered_user_factory()
+    return get_header_dict_from_user(user)
 
 
 @pytest.fixture(scope="function")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -603,3 +603,11 @@ def random_valid_upload_file(
     filename = "file"
     upload_file = fastapi.UploadFile(filename, file=file_object)
     return upload_file
+
+
+@pytest.fixture(scope="function")
+def random_valid_uuid4_str() -> str:
+    """
+    Generates and returns a random UUID4 string
+    """
+    return str(uuid4())

--- a/tests/test_add_feedback_to_event.py
+++ b/tests/test_add_feedback_to_event.py
@@ -1,0 +1,158 @@
+# pylint: disable=no-self-use
+#       - pylint test classes must pass self, even if unused.
+# pylint: disable=logging-fstring-interpolation
+#       - honestly just annoying to use lazy(%) interpolation.
+"""
+Endpoint testing for adding feedback to an event.
+"""
+import logging
+from typing import Dict, Callable, Any
+
+from asgiref.sync import async_to_sync
+from fastapi.testclient import TestClient
+from requests.models import Response as HTTPResponse
+
+from app import app
+import models.feedback as feedback_models
+import models.users as user_models
+import util.feedback as feedback_utils
+
+client = TestClient(app)
+
+
+def get_add_feedback_url_str() -> str:
+    """
+    Returns the url string for the register feedback endpoint.
+    """
+    return "/feedback/add"
+
+
+def get_payload_dict_from_reg_form(
+    feedback_reg_form: feedback_models.FeedbackRegistrationRequest
+) -> Dict[str, Any]:
+    """
+    Returns a valid dict to be used as JSON for a feedback
+    registration request
+    """
+    json_dict = feedback_reg_form.dict()
+    return json_dict
+
+
+def check_add_feedback_resp_valid(response: HTTPResponse) -> bool:
+    """
+    Checks that the incoming server response is valid,
+    returning True if all checks pass, else False.
+    """
+    try:
+        assert response.status_code == 201
+        assert response.json()
+        assert "feedback_id" in response.json()
+        assert check_feedback_added_exists(response)
+        return True
+    except AssertionError as assert_error:
+        debug_msg = f"failed at: {assert_error}. resp json: {response.json()}"
+        logging.debug(debug_msg)
+        return False
+
+
+def check_feedback_added_exists(response: HTTPResponse) -> bool:
+    """
+    Given the registration server response, ensures the feedback exists,
+    returning a boolean
+    """
+    response_feedback_id = response.json()["feedback_id"]
+    try:
+        assert async_to_sync(feedback_utils.get_feedback)(response_feedback_id)
+        return True
+    except AssertionError as compare_error:
+        debug_msg = f"failed at: {compare_error}. resp json: {response.json()}"
+        logging.debug(debug_msg)
+        return False
+
+
+class TestAddFeedback:
+    def test_add_feedback_success(
+        self,
+        valid_feedback_reg_form: feedback_models.FeedbackRegistrationRequest,
+        get_header_dict_from_user_id: Callable[[user_models.UserId],
+                                               Dict[str, Any]]):
+        """
+        Tries to register a valid feedback form, expecting success
+        """
+        headers = get_header_dict_from_user_id(
+            valid_feedback_reg_form.creator_id)
+        json_dict = get_payload_dict_from_reg_form(valid_feedback_reg_form)
+
+        request_url = get_add_feedback_url_str()
+        response = client.post(request_url, json=json_dict, headers=headers)
+        assert check_add_feedback_resp_valid(response)
+
+    def test_add_feedback_nonexistent_event_failure(  # pylint: disable=invalid-name
+        self, no_event_feedback_reg_form: feedback_models.
+        FeedbackRegistrationRequest,
+        get_header_dict_from_user_id: Callable[[user_models.UserId],
+                                               Dict[str, Any]]):
+        """
+        Attempt to add a piece of feedback without it
+        being tied to an existing event, expecting failure
+        """
+        request_url = get_add_feedback_url_str()
+        json_dict = get_payload_dict_from_reg_form(no_event_feedback_reg_form)
+        headers = get_header_dict_from_user_id(
+            no_event_feedback_reg_form.creator_id)
+
+        response = client.post(request_url, json=json_dict, headers=headers)
+        assert not check_add_feedback_resp_valid(response)
+        assert response.status_code == 404
+
+    def test_add_feedback_nonexistent_user_failure(  # pylint: disable=invalid-name
+        self,
+        no_user_feedback_reg_form: feedback_models.FeedbackRegistrationRequest,
+        get_header_dict_from_user_id: Callable[[user_models.UserId],
+                                               Dict[str, Any]]):
+        """
+        Attempt to add a piece of feedback without it
+        being tied to an existing user, expecting failure
+        """
+        request_url = get_add_feedback_url_str()
+        json_dict = get_payload_dict_from_reg_form(no_user_feedback_reg_form)
+        headers = get_header_dict_from_user_id(
+            no_user_feedback_reg_form.creator_id)
+
+        response = client.post(request_url, json=json_dict, headers=headers)
+        assert not check_add_feedback_resp_valid(response)
+        assert response.status_code == 404
+
+    def test_add_feedback_no_event_no_user_failure(  # pylint: disable=invalid-name
+        self,
+        invalid_feedback_reg_form: feedback_models.FeedbackRegistrationRequest,
+        get_header_dict_from_user_id: Callable[[user_models.UserId],
+                                               Dict[str, Any]]):
+        """
+        Attempt to add a piece of feedback without either the user or
+        the event existing, expecting failure
+        """
+        request_url = get_add_feedback_url_str()
+        json_dict = get_payload_dict_from_reg_form(invalid_feedback_reg_form)
+        headers = get_header_dict_from_user_id(
+            invalid_feedback_reg_form.creator_id)
+
+        response = client.post(request_url, json=json_dict, headers=headers)
+        assert not check_add_feedback_resp_valid(response)
+        assert response.status_code == 404
+
+    def test_add_feedback_no_data(self,
+                                  valid_header_dict_with_user_id: Dict[str,
+                                                                       Any]):
+        """
+        Tries to add a feedback object but sends no data,
+        expecting a 422 error.
+        """
+        request_url = get_add_feedback_url_str()
+        json_dict = {}
+
+        response = client.post(request_url,
+                               json=json_dict,
+                               headers=valid_header_dict_with_user_id)
+        assert not check_add_feedback_resp_valid(response)
+        assert response.status_code == 422

--- a/tests/test_auth_tokens.py
+++ b/tests/test_auth_tokens.py
@@ -27,29 +27,33 @@ def create_timedelta(minutes: int, sec: int, milli: int) -> timedelta:
 
 
 class TestAuthUser:
-    def test_encode_payload_data_ok(self, valid_payload_data_dict: Dict[str,
-                                                                        Any]):
+    def test_encode_payload_data_ok(self,
+                                    valid_header_dict_with_user_id: Dict[str,
+                                                                         Any]):
         """
         Creates a random dict and encodes it. It then
         makes sure it returns an encoded string.
         """
         encoded_token = Token.get_enc_token_str_from_dict(
-            valid_payload_data_dict)
+            valid_header_dict_with_user_id)
         is_valid = Token.check_if_valid(encoded_token)
         if is_valid:
             assert isinstance(encoded_token, str)
 
-    def test_decode_token(self, valid_payload_data_dict: Dict[str, Any]):
+    def test_decode_token(self, valid_header_dict_with_user_id: Dict[str,
+                                                                     Any]):
         """
         Creates a random dict and encodes it. It then decodes it
         and makes sure it returns a dict.
         """
         encoded_token_str = Token.get_enc_token_str_from_dict(
-            valid_payload_data_dict)
+            valid_header_dict_with_user_id)
         decoded_dict = Token.get_dict_from_enc_token_str(encoded_token_str)
-        assert set(decoded_dict.keys()) == set(valid_payload_data_dict.keys())
+        assert set(decoded_dict.keys()) == set(
+            valid_header_dict_with_user_id.keys())
 
-    def test_token_expired(self, valid_payload_data_dict: Dict[str, Any]):
+    def test_token_expired(self, valid_header_dict_with_user_id: Dict[str,
+                                                                      Any]):
         """
         Creates a random dict and a timedelta.
         Timedelta is 0 which means the token should
@@ -59,24 +63,24 @@ class TestAuthUser:
         """
         delta = create_timedelta(0, 0, 0)
         encoded_token_str = Token.get_enc_token_str_from_dict(
-            valid_payload_data_dict, delta)
+            valid_header_dict_with_user_id, delta)
         time.sleep(1)
         token_is_expired = Token.check_if_expired(encoded_token_str)
         assert token_is_expired
 
-    def test_token_not_expired_default(self,
-                                       valid_payload_data_dict: Dict[str,
-                                                                     Any]):
+    def test_token_not_expired_default(
+            self, valid_header_dict_with_user_id: Dict[str, Any]):
         """
         Creates a random dict. It then encodes the dict
         and then checks to make sure it is not expired as
         it uses the default expiry time.
         """
         encoded_token_str = Token.get_enc_token_str_from_dict(
-            valid_payload_data_dict)
+            valid_header_dict_with_user_id)
         assert not Token.check_if_expired(encoded_token_str)
 
-    def test_token_not_expired(self, valid_payload_data_dict: Dict[str, Any]):
+    def test_token_not_expired(self,
+                               valid_header_dict_with_user_id: Dict[str, Any]):
         """
         Creates a random dict and a timedelta for 5 minutes.
         It then encodes the dict and timedelta together,
@@ -84,5 +88,5 @@ class TestAuthUser:
         """
         delta = create_timedelta(5, 0, 0)
         encoded_token_str = Token.get_enc_token_str_from_dict(
-            valid_payload_data_dict, delta)
+            valid_header_dict_with_user_id, delta)
         assert not Token.check_if_expired(encoded_token_str)

--- a/tests/test_delete_user.py
+++ b/tests/test_delete_user.py
@@ -40,111 +40,74 @@ def check_delete_user_response_valid(response: HTTPResponse) -> bool:
 class TestDeleteRegularUser:
     def test_delete_user_success(
         self, registered_user: user_models.User,
+        get_header_dict_from_user: Callable[[user_models.User], Dict[str,
+                                                                     Any]],
         get_identifier_dict_from_user: Callable[[user_models.User],
                                                 Dict[str, Any]]):
         """
         Tries to delete a registered user from the database,
         expecting success.
         """
+        headers = get_header_dict_from_user(registered_user)
         json_payload = get_identifier_dict_from_user(registered_user)
         # send request to check if client is deleted
-        response = client.delete("/users/delete", json=json_payload)
+        response = client.delete("/users/delete",
+                                 json=json_payload,
+                                 headers=headers)
         # check that response is good
         assert check_delete_user_response_valid(response)
 
-    def test_delete_user_empty_data_failure(self):
+    def test_delete_user_empty_data_failure(
+            self, valid_header_dict_with_user_id: Dict[str, Any]):
         """
         Tries to delete a user without sending in a payload expecting failure.
         """
         empty_json_payload = {}
-        response = client.delete("/users/delete", json=empty_json_payload)
+        response = client.delete("/users/delete",
+                                 json=empty_json_payload,
+                                 headers=valid_header_dict_with_user_id)
 
         assert not check_delete_user_response_valid(response)
         assert response.status_code == 422
 
     def test_delete_user_nonexistent_failure(
         self, unregistered_user: user_models.User,
+        get_header_dict_from_user: Callable[[user_models.User], Dict[str,
+                                                                     Any]],
         get_identifier_dict_from_user: Callable[[user_models.User],
                                                 Dict[str, Any]]):
         """
         Tries to delete a user that does not exist
         (i.e. has not been registered), expecting failure.
         """
+        headers = get_header_dict_from_user(unregistered_user)
         fake_json_payload = get_identifier_dict_from_user(unregistered_user)
-        response = client.delete("/users/delete", json=fake_json_payload)
+        response = client.delete("/users/delete",
+                                 json=fake_json_payload,
+                                 headers=headers)
 
         assert not check_delete_user_response_valid(response)
         assert response.status_code == 404
 
     def test_delete_user_twice_failure(
         self, registered_user: user_models.User,
+        get_header_dict_from_user: Callable[[user_models.User], Dict[str,
+                                                                     Any]],
         get_identifier_dict_from_user: Callable[[user_models.User],
                                                 Dict[str, Any]]):
         """
         Deletes a valid registered user, then tries to delete it again,
         expecting failure from the second request.
         """
+        headers = get_header_dict_from_user(registered_user)
         json_payload = get_identifier_dict_from_user(registered_user)
-        response = client.delete("/users/delete", json=json_payload)
+        response = client.delete("/users/delete",
+                                 json=json_payload,
+                                 headers=headers)
         assert check_delete_user_response_valid(response)
 
-        failed_response = client.delete("/users/delete", json=json_payload)
-        assert not check_delete_user_response_valid(failed_response)
-        assert failed_response.status_code == 404
-
-
-class TestDeleteAdminUser:
-    def test_delete_user_success(
-        self, registered_admin_user: user_models.User,
-        get_identifier_dict_from_user: Callable[[user_models.User],
-                                                Dict[str, Any]]):
-        """
-        Tries to delete a registered_admin user from the database,
-        expecting success.
-        """
-        json_payload = get_identifier_dict_from_user(registered_admin_user)
-        # send request to check if client is deleted
-        response = client.delete("/users/delete", json=json_payload)
-        # check that response is good
-        assert check_delete_user_response_valid(response)
-
-    def test_delete_user_empty_data_failure(self):
-        """
-        Tries to delete a user without sending in a payload expecting failure.
-        """
-        empty_json_payload = {}
-        response = client.delete("/users/delete", json=empty_json_payload)
-
-        assert not check_delete_user_response_valid(response)
-        assert response.status_code == 422
-
-    def test_delete_user_nonexistent_failure(
-        self, unregistered_admin_user: user_models.User,
-        get_identifier_dict_from_user: Callable[[user_models.User],
-                                                Dict[str, Any]]):
-        """
-        Tries to delete a user that does not exist
-        (i.e. has not been registered_admin), expecting failure.
-        """
-        fake_json_payload = get_identifier_dict_from_user(
-            unregistered_admin_user)
-        response = client.delete("/users/delete", json=fake_json_payload)
-
-        assert not check_delete_user_response_valid(response)
-        assert response.status_code == 404
-
-    def test_delete_user_twice_failure(
-        self, registered_admin_user: user_models.User,
-        get_identifier_dict_from_user: Callable[[user_models.User],
-                                                Dict[str, Any]]):
-        """
-        Deletes a valid registered_admin user, then tries to delete it again,
-        expecting failure from the second request.
-        """
-        json_payload = get_identifier_dict_from_user(registered_admin_user)
-        response = client.delete("/users/delete", json=json_payload)
-        assert check_delete_user_response_valid(response)
-
-        failed_response = client.delete("/users/delete", json=json_payload)
+        failed_response = client.delete("/users/delete",
+                                        json=json_payload,
+                                        headers=headers)
         assert not check_delete_user_response_valid(failed_response)
         assert failed_response.status_code == 404

--- a/tests/test_event_registration.py
+++ b/tests/test_event_registration.py
@@ -87,13 +87,13 @@ def set_datetimes_to_str_in_place(json_dict: Dict[str, Any]) -> None:
 class TestRegisterEvent:
     def test_register_event_success(
         self, event_registration_form: event_models.EventRegistrationForm,
-        get_valid_header_token_dict_from_user_id: Callable[[user_models.User],
+        get_header_dict_from_user_id: Callable[[user_models.User],
                                                            Dict[str, Any]]):
         """
         Attempts to register a valid event, expecting success.
         """
         creator_user_id = event_registration_form.creator_id
-        headers = get_valid_header_token_dict_from_user_id(creator_user_id)
+        headers = get_header_dict_from_user_id(creator_user_id)
 
         event_form_json = get_json_from_event_reg_form(event_registration_form)
 
@@ -105,14 +105,14 @@ class TestRegisterEvent:
 
     def test_register_event_no_data_failure(
         self, event_registration_form: event_models.EventRegistrationForm,
-        get_valid_header_token_dict_from_user_id: Callable[[user_models.User],
+        get_header_dict_from_user_id: Callable[[user_models.User],
                                                            Dict[str, Any]]):
         """
         Tries to register an event while sending no data,
         expecting failure.
         """
         creator_user_id = event_registration_form.creator_id
-        headers = get_valid_header_token_dict_from_user_id(creator_user_id)
+        headers = get_header_dict_from_user_id(creator_user_id)
 
         empty_event_form = {}
 
@@ -126,14 +126,14 @@ class TestRegisterEvent:
 
     def test_register_event_bad_data_failure(
         self, event_registration_form: event_models.EventRegistrationForm,
-        get_valid_header_token_dict_from_user_id: Callable[[user_models.User],
+        get_header_dict_from_user_id: Callable[[user_models.User],
                                                            Dict[str, Any]]):
         """
         Tries to register an event with a faulty piece of data,
         expecting a 422 failure.
         """
         creator_user_id = event_registration_form.creator_id
-        headers = get_valid_header_token_dict_from_user_id(creator_user_id)
+        headers = get_header_dict_from_user_id(creator_user_id)
 
         invalid_event_json = get_invalid_json_from_reg_form(
             event_registration_form)
@@ -149,7 +149,7 @@ class TestRegisterEvent:
     def test_register_nonexistent_user(
         self, random_valid_uuid4_str: str,
         event_registration_form: event_models.EventRegistrationForm,
-        get_valid_header_token_dict_from_user_id: Callable[[user_models.User],
+        get_header_dict_from_user_id: Callable[[user_models.User],
                                                            Dict[str, Any]]):
         """
         Attempts to register a valid event but with a nonexistent user,
@@ -158,7 +158,7 @@ class TestRegisterEvent:
         # change creator id in event and header to a random id
         nonexistent_user_id = random_valid_uuid4_str
         event_registration_form.creator_id = nonexistent_user_id
-        headers = get_valid_header_token_dict_from_user_id(nonexistent_user_id)
+        headers = get_header_dict_from_user_id(nonexistent_user_id)
 
         event_form_json = get_json_from_event_reg_form(event_registration_form)
 
@@ -172,14 +172,14 @@ class TestRegisterEvent:
     def test_bad_header_creator_id(
         self, registered_user: user_models.User,
         event_registration_form: event_models.EventRegistrationForm,
-        get_valid_header_token_dict_from_user: Callable[[user_models.User],
+        get_header_dict_from_user: Callable[[user_models.User],
                                                         Dict[str, Any]]):
         """
         Attempts to register a valid event, but sends in an erroneous
         header containing the ID for a different, valid user.
         Expects 401 auth error.
         """
-        wrong_user_header = get_valid_header_token_dict_from_user(
+        wrong_user_header = get_header_dict_from_user(
             registered_user)
 
         event_form_json = get_json_from_event_reg_form(event_registration_form)

--- a/tests/test_event_registration.py
+++ b/tests/test_event_registration.py
@@ -16,8 +16,8 @@ from fastapi.testclient import TestClient
 from requests.models import Response as HTTPResponse
 
 from app import app
-import models.events as event_models
 import models.users as user_models
+import models.events as event_models
 
 client = TestClient(app)
 
@@ -145,3 +145,48 @@ class TestRegisterEvent:
 
         assert not check_event_registration_response_valid(event_response)
         assert event_response.status_code == 422
+
+    def test_register_nonexistent_user(
+        self, random_valid_uuid4_str: str,
+        event_registration_form: event_models.EventRegistrationForm,
+        get_valid_header_token_dict_from_user_id: Callable[[user_models.User],
+                                                           Dict[str, Any]]):
+        """
+        Attempts to register a valid event but with a nonexistent user,
+        expecting 404 failure.
+        """
+        # change creator id in event and header to a random id
+        nonexistent_user_id = random_valid_uuid4_str
+        event_registration_form.creator_id = nonexistent_user_id
+        headers = get_valid_header_token_dict_from_user_id(nonexistent_user_id)
+
+        event_form_json = get_json_from_event_reg_form(event_registration_form)
+
+        endpoint_url = get_reg_event_endpoint_url_str()
+        event_response = client.post(endpoint_url,
+                                     json=event_form_json,
+                                     headers=headers)
+        assert not check_event_registration_response_valid(event_response)
+        assert event_response.status_code == 404
+
+    def test_bad_header_creator_id(
+        self, registered_user: user_models.User,
+        event_registration_form: event_models.EventRegistrationForm,
+        get_valid_header_token_dict_from_user: Callable[[user_models.User],
+                                                        Dict[str, Any]]):
+        """
+        Attempts to register a valid event, but sends in an erroneous
+        header containing the ID for a different, valid user.
+        Expects 401 auth error.
+        """
+        wrong_user_header = get_valid_header_token_dict_from_user(
+            registered_user)
+
+        event_form_json = get_json_from_event_reg_form(event_registration_form)
+
+        endpoint_url = get_reg_event_endpoint_url_str()
+        event_response = client.post(endpoint_url,
+                                     json=event_form_json,
+                                     headers=wrong_user_header)
+        assert not check_event_registration_response_valid(event_response)
+        assert event_response.status_code == 401

--- a/tests/test_event_registration.py
+++ b/tests/test_event_registration.py
@@ -10,13 +10,14 @@ Endpoint tests for registering events.
 """
 import logging
 import datetime
-from typing import Dict, Any
+from typing import Dict, Any, Callable
 
 from fastapi.testclient import TestClient
 from requests.models import Response as HTTPResponse
 
 from app import app
 import models.events as event_models
+import models.users as user_models
 
 client = TestClient(app)
 
@@ -85,40 +86,62 @@ def set_datetimes_to_str_in_place(json_dict: Dict[str, Any]) -> None:
 
 class TestRegisterEvent:
     def test_register_event_success(
-            self, event_registration_form: event_models.EventRegistrationForm):
+        self, event_registration_form: event_models.EventRegistrationForm,
+        get_valid_header_token_dict_from_user_id: Callable[[user_models.User],
+                                                           Dict[str, Any]]):
         """
         Attempts to register a valid event, expecting success.
         """
+        creator_user_id = event_registration_form.creator_id
+        headers = get_valid_header_token_dict_from_user_id(creator_user_id)
+
         event_form_json = get_json_from_event_reg_form(event_registration_form)
 
         endpoint_url = get_reg_event_endpoint_url_str()
-        event_response = client.post(endpoint_url, json=event_form_json)
+        event_response = client.post(endpoint_url,
+                                     json=event_form_json,
+                                     headers=headers)
         assert check_event_registration_response_valid(event_response)
 
-    def test_register_event_no_data_failure(self):
+    def test_register_event_no_data_failure(
+        self, event_registration_form: event_models.EventRegistrationForm,
+        get_valid_header_token_dict_from_user_id: Callable[[user_models.User],
+                                                           Dict[str, Any]]):
         """
         Tries to register an event while sending no data,
         expecting failure.
         """
+        creator_user_id = event_registration_form.creator_id
+        headers = get_valid_header_token_dict_from_user_id(creator_user_id)
+
         empty_event_form = {}
 
         endpoint_url = get_reg_event_endpoint_url_str()
-        event_response = client.post(endpoint_url, json=empty_event_form)
+        event_response = client.post(endpoint_url,
+                                     json=empty_event_form,
+                                     headers=headers)
 
         assert not check_event_registration_response_valid(event_response)
         assert event_response.status_code == 422
 
     def test_register_event_bad_data_failure(
-            self, event_registration_form: event_models.EventRegistrationForm):
+        self, event_registration_form: event_models.EventRegistrationForm,
+        get_valid_header_token_dict_from_user_id: Callable[[user_models.User],
+                                                           Dict[str, Any]]):
         """
         Tries to register an event with a faulty piece of data,
         expecting a 422 failure.
         """
+        creator_user_id = event_registration_form.creator_id
+        headers = get_valid_header_token_dict_from_user_id(creator_user_id)
+
         invalid_event_json = get_invalid_json_from_reg_form(
             event_registration_form)
 
         endpoint_url = get_reg_event_endpoint_url_str()
-        event_response = client.post(endpoint_url, json=invalid_event_json)
+        event_response = client.post(endpoint_url,
+                                     json=invalid_event_json,
+                                     headers=headers)
 
         assert not check_event_registration_response_valid(event_response)
         assert event_response.status_code == 422

--- a/tests/test_token_header_auth.py
+++ b/tests/test_token_header_auth.py
@@ -157,8 +157,8 @@ class TestAuthHeaderHandler:
     """
     class TestGetAuthTokenFromHeader:
         class TestRequiredHeader:
-            def test_header_token_ok(self, valid_header_token_dict: Dict[str,
-                                                                         str]):
+            def test_header_token_ok(
+                    self, valid_header_dict_with_user_id: Dict[str, str]):
                 """
                 Calls the endpoint that tests the `get_auth_token_from_header`
                 method with a valid header, expecting to get back the same
@@ -166,9 +166,9 @@ class TestAuthHeaderHandler:
                 """
                 endpoint_url = get_token_str_endpoint_url_str()
                 response = client.get(endpoint_url,
-                                      headers=valid_header_token_dict)
-                assert check_token_str_response_valid(response,
-                                                      valid_header_token_dict)
+                                      headers=valid_header_dict_with_user_id)
+                assert check_token_str_response_valid(
+                    response, valid_header_dict_with_user_id)
 
             def test_invalid_header_token_str(
                     self, invalid_token_header_dict: Dict[str, str]):
@@ -195,8 +195,8 @@ class TestAuthHeaderHandler:
                 assert response.status_code == 422
 
         class TestOptionalHeader:
-            def test_header_token_ok(self, valid_header_token_dict: Dict[str,
-                                                                         str]):
+            def test_header_token_ok(
+                    self, valid_header_dict_with_user_id: Dict[str, str]):
                 """
                 Calls the endpoint that tests the `get_auth_token_from_header`
                 method with a valid header, expecting to get back the same
@@ -204,9 +204,9 @@ class TestAuthHeaderHandler:
                 """
                 endpoint_url = get_optional_token_str_endpoint_url_str()
                 response = client.get(endpoint_url,
-                                      headers=valid_header_token_dict)
-                assert check_token_str_response_valid(response,
-                                                      valid_header_token_dict)
+                                      headers=valid_header_dict_with_user_id)
+                assert check_token_str_response_valid(
+                    response, valid_header_dict_with_user_id)
 
             def test_invalid_header_token_str(
                     self, invalid_token_header_dict: Dict[str, str]):
@@ -233,18 +233,18 @@ class TestAuthHeaderHandler:
                 assert check_response_valid_but_empty(response)
 
     class TestDecodeTokenAndGetPayload:
-        def test_payload_decodable_ok(self,
-                                      valid_header_token_dict: Dict[str, str]):
+        def test_payload_decodable_ok(
+                self, valid_header_dict_with_user_id: Dict[str, str]):
             """
             Sends in a token_str header with some payload, expecting to be
             returned the same payload passed in.
             """
             endpoint_url = get_optional_decode_token_payload_endpoint()
             response = client.get(endpoint_url,
-                                  headers=valid_header_token_dict)
+                                  headers=valid_header_dict_with_user_id)
 
             assert check_get_payload_from_token_response_valid(
-                response, valid_header_token_dict)
+                response, valid_header_dict_with_user_id)
 
         def test_invalid_header_token_str(
                 self, invalid_token_header_dict: Dict[str, str]):

--- a/tests/test_upload_image.py
+++ b/tests/test_upload_image.py
@@ -29,31 +29,68 @@ def get_upload_image_endpoint_url() -> str:
 
 
 class TestImageUploadEndpoint:
-    def test_upload_image_ok_success(self, valid_file_data_dict: Dict[str,
-                                                                      Any]):
+    def test_upload_image_ok_success(self,
+                                     valid_header_dict_with_user_id: Dict[str,
+                                                                          Any],
+                                     valid_file_data_dict: Dict[str, Any]):
         """
-        Uploads a valid image file using the endpoint, expecting success.
+        Uploads a valid image file using the endpoint and passing in
+        a valid header for an existing user, expecting success.
+        """
+        endpoint_url = get_upload_image_endpoint_url()
+        response = client.post(endpoint_url,
+                               files=valid_file_data_dict,
+                               headers=valid_header_dict_with_user_id)
+        assert check_upload_image_resp_valid(response)
+
+    def test_upload_no_header_failure(self, valid_file_data_dict: Dict[str,
+                                                                       Any]):
+        """
+        Tries to upload an image without passing
+        in an auth token header, expecting failure
         """
         endpoint_url = get_upload_image_endpoint_url()
         response = client.post(endpoint_url, files=valid_file_data_dict)
-        assert check_upload_image_resp_valid(response)
+        assert not check_upload_image_resp_valid(response)
+        assert response.status_code == 422
 
-    def test_upload_image_no_data_fail(self):
+    def test_upload_image_fake_user(self,
+                                    nonexistent_user_header_dict: Dict[str,
+                                                                       Any],
+                                    valid_file_data_dict: Dict[str, Any]):
+        """
+        Tries to upload an image with an invalid auth token, expecting failure
+        """
+        endpoint_url = get_upload_image_endpoint_url()
+        response = client.post(endpoint_url,
+                               files=valid_file_data_dict,
+                               headers=nonexistent_user_header_dict)
+        assert not check_upload_image_resp_valid(response)
+        assert response.status_code == 404
+
+    def test_upload_image_no_data_fail(
+            self, valid_header_dict_with_user_id: Dict[str, Any]):
         """
         Tries to upload empty data to the endpoint, expecting failure.
         """
         empty_file_data = {}
         endpoint_url = get_upload_image_endpoint_url()
-        response = client.post(endpoint_url, files=empty_file_data)
+        response = client.post(endpoint_url,
+                               files=empty_file_data,
+                               headers=valid_header_dict_with_user_id)
         assert not check_upload_image_resp_valid(response)
         assert response.status_code == 422
 
-    def test_upload_bad_data_fail(self, invalid_file_data_dict: Dict[str,
-                                                                     Any]):
+    def test_upload_bad_data_fail(self,
+                                  valid_header_dict_with_user_id: Dict[str,
+                                                                       Any],
+                                  invalid_file_data_dict: Dict[str, Any]):
         """
         Sends bad (non-valid file) data to the endpoint, expecting failure.
         """
         endpoint_url = get_upload_image_endpoint_url()
-        response = client.post(endpoint_url, files=invalid_file_data_dict)
+        response = client.post(endpoint_url,
+                               files=invalid_file_data_dict,
+                               headers=valid_header_dict_with_user_id)
         assert not check_upload_image_resp_valid(response)
         assert response.status_code == 422

--- a/tests/test_validate_token_endpoint.py
+++ b/tests/test_validate_token_endpoint.py
@@ -38,13 +38,15 @@ def check_validation_response_ok(response: HTTPResponse) -> bool:
 
 
 class TestValidateTokenEndpoint:
-    def test_header_token_valid_ok(self, valid_header_token_dict: Dict[str,
-                                                                       str]):
+    def test_header_token_valid_ok(self,
+                                   valid_header_dict_with_user_id: Dict[str,
+                                                                        str]):
         """
         Tries to validate a valid token expecting success.
         """
         endpoint_url = get_validate_token_endpoint()
-        response = client.get(endpoint_url, headers=valid_header_token_dict)
+        response = client.get(endpoint_url,
+                              headers=valid_header_dict_with_user_id)
         assert check_validation_response_ok(response)
 
     def test_invalid_header_token_str(self,

--- a/util/auth.py
+++ b/util/auth.py
@@ -11,6 +11,22 @@ from typing import Dict, Any, Optional
 from fastapi import Header
 from models.auth import Token
 from models import exceptions
+import models.users as user_models
+import util.users as user_utils
+
+
+async def get_user_id_from_header_and_check_existence(  # pylint: disable=invalid-name
+        token: str = Header(None)) -> user_models.UserId:
+    """
+    Gets the token from the header and treats it as a `UserId`,
+    checking for existence of the user, else raising a 404.
+
+    If valid and existent, returns the value of the UserId.
+    """
+    payload_dict = await get_payload_from_token_header(token)
+    user_id = payload_dict["user_id"]
+    await user_utils.check_if_user_exists_by_id(user_id)
+    return user_id
 
 
 async def get_auth_token_from_header(token: str = Header(None)) -> str:

--- a/util/auth.py
+++ b/util/auth.py
@@ -24,7 +24,10 @@ async def get_user_id_from_header_and_check_existence(  # pylint: disable=invali
     If valid and existent, returns the value of the UserId.
     """
     payload_dict = await get_payload_from_token_header(token)
-    user_id = payload_dict["user_id"]
+    user_id = payload_dict.get("user_id")
+    if not user_id:
+        detail = "User ID not in JWT header payload dict."
+        raise exceptions.InvalidDataException(detail=detail)
     await user_utils.check_if_user_exists_by_id(user_id)
     return user_id
 

--- a/util/events.py
+++ b/util/events.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Any, Tuple
 from geopy import distance
 
 from models import exceptions
+import util.users as user_utils
 import models.users as user_models
 import models.events as event_models
 from config.db import get_database, get_database_client_name
@@ -16,15 +17,14 @@ def events_collection():
 
 
 async def register_event(
-    event_registration_form: event_models.EventRegistrationForm,
-    user_id_from_token: user_models.UserId
+    event_registration_form: event_models.EventRegistrationForm
 ) -> event_models.EventRegistrationResponse:
     """
     Takes an event registration object and inserts it into the database
     after validating it's data and ownership.
     """
-    await check_user_id_matches_reg_form(event_registration_form,
-                                         user_id_from_token)
+    creator_user_id = event_registration_form.creator_id
+    await user_utils.check_if_user_exists_by_id(creator_user_id)
 
     event = await get_event_from_event_reg_form(event_registration_form)
     events_collection().insert_one(event.dict())

--- a/util/events.py
+++ b/util/events.py
@@ -5,6 +5,7 @@ from typing import Dict, List, Any, Tuple
 from geopy import distance
 
 from models import exceptions
+import models.users as user_models
 import models.events as event_models
 from config.db import get_database, get_database_client_name
 
@@ -15,18 +16,37 @@ def events_collection():
 
 
 async def register_event(
-    event_registration_form: event_models.EventRegistrationForm
+    event_registration_form: event_models.EventRegistrationForm,
+    user_id_from_token: user_models.UserId
 ) -> event_models.EventRegistrationResponse:
     """
     Takes an event registration object and inserts it into the database
+    after validating it's data and ownership.
     """
-    event = await get_event_from_event_reg_form(event_registration_form)
+    await check_user_id_matches_reg_form(event_registration_form,
+                                         user_id_from_token)
 
+    event = await get_event_from_event_reg_form(event_registration_form)
     events_collection().insert_one(event.dict())
 
     # return user_id if success
     event_id = event.get_id()
     return event_models.EventRegistrationResponse(event_id=event_id)
+
+
+async def check_user_id_matches_reg_form(
+        reg_form: event_models.EventRegistrationForm,
+        user_id: user_models.UserId) -> None:
+    """
+    Checks that the event registration form has the same
+    `creator_id` value as the `user_id` passed in.
+
+    Raises exception if not, else returns silently.
+    """
+    creator_id = reg_form.creator_id
+    if not creator_id == user_id:
+        detail = "Token passed in does not match creator ID for the event form"
+        raise exceptions.InvalidAuthHeaderException(detail=detail)
 
 
 async def get_event_from_event_reg_form(

--- a/util/feedback.py
+++ b/util/feedback.py
@@ -3,6 +3,7 @@ Handlers for feedback operations.
 """
 from config.db import get_database, get_database_client_name
 from models import exceptions
+import models.users as user_models
 import models.events as event_models
 import models.feedback as feedback_models
 
@@ -17,7 +18,8 @@ def events_collection():
 
 
 async def delete_feedback(event_id: event_models.EventId,
-                          feedback_id: feedback_models.FeedbackId) -> None:
+                          feedback_id: feedback_models.FeedbackId,
+                          user_id_from_token: user_models.UserId) -> None:
     """
     Given an event id and feedback id, attempt to delete the feedback from
     the event's comment_ids array as well as from the feedback collection
@@ -26,16 +28,24 @@ async def delete_feedback(event_id: event_models.EventId,
 
     if not found_event:
         raise exceptions.EventNotFoundException
-
     if feedback_id not in found_event["comment_ids"]:
         raise exceptions.FeedbackNotFoundException
+
+    feedback_query = {"_id": feedback_id}
+    found_comment_document = feedback_collection().find_one(feedback_query)
+
+    if not found_comment_document:
+        raise exceptions.FeedbackNotFoundException
+    if found_comment_document["creator_id"] != user_id_from_token:
+        detail = "User ID does not match creator ID for the comment"
+        raise exceptions.UnauthorizedIdentifierData(detail=detail)
 
     # remove the feedback ID from the event then update the DB document to match
     found_event["comment_ids"].remove(feedback_id)
     events_collection().update_one({"_id": event_id}, {"$set": found_event})
 
     # remove feedback from the feedback collection
-    feedback_collection().delete_one({"_id": feedback_id})
+    feedback_collection().delete_one(feedback_query)
 
 
 async def register_feedback(
@@ -50,13 +60,13 @@ async def register_feedback(
     if not found_event:
         raise exceptions.EventNotFoundException
 
+    # insert the feedback into the feedback collection
+    feedback_collection().insert_one(registration_form.dict())
+
     # add feedback id to event and update it in the database
     feedback_id = registration_form.get_id()
     found_event["comment_ids"].append(feedback_id)
     events_collection().update_one({"_id": event_id}, {"$set": found_event})
-
-    # finally, insert the feedback into the feedback collection
-    feedback_collection().insert_one(registration_form.dict())
 
     return feedback_id
 

--- a/util/feedback.py
+++ b/util/feedback.py
@@ -61,14 +61,26 @@ async def register_feedback(
         raise exceptions.EventNotFoundException
 
     # insert the feedback into the feedback collection
-    feedback_collection().insert_one(registration_form.dict())
+    valid_feedback = await get_feedback_from_reg_form(registration_form)
+    feedback_collection().insert_one(valid_feedback.dict())
 
     # add feedback id to event and update it in the database
-    feedback_id = registration_form.get_id()
+    feedback_id = valid_feedback.get_id()
     found_event["comment_ids"].append(feedback_id)
     events_collection().update_one({"_id": event_id}, {"$set": found_event})
 
     return feedback_id
+
+
+async def get_feedback_from_reg_form(
+    reg_form: feedback_models.FeedbackRegistrationRequest
+) -> feedback_models.Feedback:
+    """
+    Validates and creates a valid feedback object from an incoming registration
+    form and returns it.
+    """
+    valid_feedback = feedback_models.Feedback(**reg_form.dict())
+    return valid_feedback
 
 
 async def get_feedback(

--- a/util/users.py
+++ b/util/users.py
@@ -83,8 +83,12 @@ async def check_if_user_exists_by_id(user_id: user_models.UserId) -> None:
 
 async def delete_user(identifier: user_models.UserIdentifier) -> None:
     """
-    Deletes a user by it's identifier
+    Deletes a user by it's identifier.
+
+    Raises an error if the user does not exist or if the credentials
+    don't match the identifier
     """
+
     query = identifier.get_database_query()
     response = users_collection().delete_one(query)
     if response.deleted_count == 0:

--- a/util/users.py
+++ b/util/users.py
@@ -7,10 +7,11 @@ the `config.db` module like all other `util` modules.
 from typing import Dict, Any
 
 import pymongo.errors as pymongo_exceptions
-from config.db import get_database, get_database_client_name
+
+from models.auth import Token
 from models import exceptions
 import models.users as user_models
-from models.auth import Token
+from config.db import get_database, get_database_client_name
 
 
 # instantiate the main collection to use for this util file for convenience
@@ -69,6 +70,15 @@ async def get_user_info_by_identifier(
 
     # cast the database response into a User object
     return user_models.User(**user_document)
+
+
+async def check_if_user_exists_by_id(user_id: user_models.UserId) -> None:
+    """
+    Checks if the user exists solely by ID and raises an
+    exception if it does, else returns None silently.
+    """
+    user_identifier = user_models.UserIdentifier(user_id=user_id)
+    await get_user_info_by_identifier(user_identifier)
 
 
 async def delete_user(identifier: user_models.UserIdentifier) -> None:


### PR DESCRIPTION
Huge push of code that not only added true handling of auth headers to the endpoints that should have them, but also heavily bolstered up tests and code to handle edge cases.

Resiliency and correctness of events and feedback in particular should be up 10x, tests are also a bit more restrictive.

